### PR TITLE
fix:Error in generating manifest output for helm charts deployed via gitops or helm when resource is present previously.

### DIFF
--- a/pkg/helmClient/client.go
+++ b/pkg/helmClient/client.go
@@ -514,7 +514,7 @@ func (c *HelmClient) TemplateChart(spec *ChartSpec, options *HelmTemplateOptions
 		client.Version = ">0.0.0-0"
 	}
 	ChartPathOptions := action.ChartPathOptions{
-		RepoURL: "https://charts.bitnami.com/bitnami",
+		RepoURL: spec.RepoURL,
 	}
 	client.ChartPathOptions = ChartPathOptions
 	helmChart, chartPath, err := c.getChart(spec.ChartName, &client.ChartPathOptions)

--- a/pkg/helmClient/interface.go
+++ b/pkg/helmClient/interface.go
@@ -22,4 +22,5 @@ type Client interface {
 	UpgradeReleaseWithChartInfo(ctx context.Context, spec *ChartSpec) (*release.Release, error)
 	IsReleaseInstalled(ctx context.Context, releaseName string, releaseNamespace string) (bool, error)
 	RollbackRelease(spec *ChartSpec, version int) error
+	TemplateChart(spec *ChartSpec, options *HelmTemplateOptions) ([]byte, error)
 }

--- a/pkg/helmClient/types.go
+++ b/pkg/helmClient/types.go
@@ -123,7 +123,8 @@ type ChartSpec struct {
 	// WaitForJobs indicates whether to wait for completion of release Jobs before marking the release as successful.
 	// 'Wait' has to be specified for this to take effect.
 	// The timeout may be specified via the 'Timeout' field.
-	WaitForJobs bool `json:"waitForJobs,omitempty"`
+	WaitForJobs bool   `json:"waitForJobs,omitempty"`
+	RepoURL     string `json:"repoURL,omitempty"`
 }
 type HelmTemplateOptions struct {
 	KubeVersion *chartutil.KubeVersion

--- a/pkg/helmClient/types.go
+++ b/pkg/helmClient/types.go
@@ -1,7 +1,9 @@
 package helmClient
 
 import (
+	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/getter"
+	"io"
 	"k8s.io/client-go/rest"
 	"time"
 
@@ -9,7 +11,6 @@ import (
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/repo"
 )
-
 
 // RestConfClientOptions defines the options used for constructing a client via REST config
 type RestConfClientOptions struct {
@@ -42,6 +43,7 @@ type HelmClient struct {
 	ActionConfig *action.Configuration
 	linting      bool
 	DebugLog     action.DebugLog
+	output       io.Writer
 }
 
 // ChartSpec defines the values of a helm chart
@@ -118,4 +120,13 @@ type ChartSpec struct {
 	// DryRun indicates whether to perform a dry run.
 	// +optional
 	DryRun bool `json:"dryRun,omitempty"`
+	// WaitForJobs indicates whether to wait for completion of release Jobs before marking the release as successful.
+	// 'Wait' has to be specified for this to take effect.
+	// The timeout may be specified via the 'Timeout' field.
+	WaitForJobs bool `json:"waitForJobs,omitempty"`
+}
+type HelmTemplateOptions struct {
+	KubeVersion *chartutil.KubeVersion
+	// APIVersions defined here will be appended to the default list helm provides
+	APIVersions chartutil.VersionSet
 }

--- a/pkg/service/HelmAppService.go
+++ b/pkg/service/HelmAppService.go
@@ -650,19 +650,35 @@ func (impl HelmAppServiceImpl) RollbackRelease(request *client.RollbackReleaseRe
 	return true, nil
 }
 
-// TemplateChart returns a rendered version of the provided ChartSpec 'spec' by performing a "dry-run" install.
+//TemplateChart returns a rendered version of the provided ChartSpec 'spec' by performing a "dry-run" install.
+
+//func (impl HelmAppServiceImpl) TemplateChart(ctx context.Context, request *client.InstallReleaseRequest) (string, error) {
+//	// Install release starts with dry-run
+//	rel, err := impl.installRelease(request, true)
+//	if err != nil {
+//		return "", err
+//	}
+//	// Install release ends with dry-run
+//
+//	if rel == nil {
+//		return "", errors.New("release is found nil")
+//	}
+//	return rel.Manifest, nil
+//}
+
 func (impl HelmAppServiceImpl) TemplateChart(ctx context.Context, request *client.InstallReleaseRequest) (string, error) {
-	// Install release starts with dry-run
-	rel, err := impl.installRelease(request, true)
+	//cmd := exec.Command("helm", "template", "dt-secrets-test", "-n", "devtroncd", "devtron/dt-secrets")
+	//output, err := cmd.Output()
+
+	//if cmd == nil {
+	//	return "", errors.New("release is found nil")
+	//}
+	//Manifest := string(output)
+	releaseObject, err := getHelmRelease(request.ReleaseIdentifier.ClusterConfig, request.ReleaseIdentifier.ReleaseNamespace, request.ReleaseIdentifier.ReleaseName)
 	if err != nil {
 		return "", err
 	}
-	// Install release ends with dry-run
-
-	if rel == nil {
-		return "", errors.New("release is found nil")
-	}
-	return rel.Manifest, nil
+	return releaseObject.Manifest, nil
 }
 
 func getHelmRelease(clusterConfig *client.ClusterConfig, namespace string, releaseName string) (*release.Release, error) {

--- a/pkg/service/HelmAppService.go
+++ b/pkg/service/HelmAppService.go
@@ -650,22 +650,6 @@ func (impl HelmAppServiceImpl) RollbackRelease(request *client.RollbackReleaseRe
 	return true, nil
 }
 
-//TemplateChart returns a rendered version of the provided ChartSpec 'spec' by performing a "dry-run" install.
-
-//func (impl HelmAppServiceImpl) TemplateChart(ctx context.Context, request *client.InstallReleaseRequest) (string, error) {
-//	// Install release starts with dry-run
-//	rel, err := impl.installRelease(request, true)
-//	if err != nil {
-//		return "", err
-//	}
-//	// Install release ends with dry-run
-//
-//	if rel == nil {
-//		return "", errors.New("release is found nil")
-//	}
-//	return rel.Manifest, nil
-//}
-
 func (impl HelmAppServiceImpl) TemplateChart(ctx context.Context, request *client.InstallReleaseRequest) (string, error) {
 	releaseIdentifier := request.ReleaseIdentifier
 	helmClientObj, err := impl.getHelmClient(releaseIdentifier.ClusterConfig, releaseIdentifier.ReleaseNamespace)

--- a/pkg/service/HelmAppService.go
+++ b/pkg/service/HelmAppService.go
@@ -32,6 +32,7 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -667,18 +668,25 @@ func (impl HelmAppServiceImpl) RollbackRelease(request *client.RollbackReleaseRe
 //}
 
 func (impl HelmAppServiceImpl) TemplateChart(ctx context.Context, request *client.InstallReleaseRequest) (string, error) {
-	//cmd := exec.Command("helm", "template", "dt-secrets-test", "-n", "devtroncd", "devtron/dt-secrets")
-	//output, err := cmd.Output()
+	releaseName := request.ReleaseIdentifier.ReleaseName
+	releaseNamespace := request.ReleaseIdentifier.ReleaseNamespace
 
-	//if cmd == nil {
-	//	return "", errors.New("release is found nil")
-	//}
-	//Manifest := string(output)
-	releaseObject, err := getHelmRelease(request.ReleaseIdentifier.ClusterConfig, request.ReleaseIdentifier.ReleaseNamespace, request.ReleaseIdentifier.ReleaseName)
+	cmd := exec.Command("helm", "template", releaseName, "-n", releaseNamespace, "devtron/dt-secrets")
+	output, err := cmd.Output()
 	if err != nil {
 		return "", err
 	}
-	return releaseObject.Manifest, nil
+
+	if cmd == nil {
+		return "", errors.New("release is found nil")
+	}
+	manifest := string(output)
+	//releaseObject, err := getHelmRelease(request.ReleaseIdentifier.ClusterConfig, request.ReleaseIdentifier.ReleaseNamespace, request.ReleaseIdentifier.ReleaseName)
+	//if err != nil {
+	//	return "", err
+	//}
+	//return releaseObject.Manifest, nil
+	return manifest, nil
 }
 
 func getHelmRelease(clusterConfig *client.ClusterConfig, namespace string, releaseName string) (*release.Release, error) {

--- a/pkg/service/HelmAppService.go
+++ b/pkg/service/HelmAppService.go
@@ -675,6 +675,7 @@ func (impl HelmAppServiceImpl) TemplateChart(ctx context.Context, request *clien
 		ChartName:     request.ChartName,
 		CleanupOnFail: true, // allow deletion of new resources created in this rollback when rollback fails
 		MaxHistory:    0,    // limit the maximum number of revisions saved per release. Use 0 for no limit (default 10)
+		RepoURL:       request.ChartRepository.Url,
 	}
 	HelmTemplateOptions := &helmClient.HelmTemplateOptions{}
 


### PR DESCRIPTION
# Description
This feature will remove error for Manifest output in configure tab

Fixes [AB36](https://github.com/devtron-labs/kubelink/issues/36)
## How Has This Been Tested?
1. I have done testing this via image deployment on vm.
2. I have checked for all possible test cases.
Test cases are:-
a.deployed  helm chart when no apps is present.
b.deleted above helm app and again installed same chart with same name.
c. deployed  same helm chart again when above app  is present.
d.deployed helm chart via gitOps.
e.deployed helm chart via helm.
4. I have also done testing by applying multiple breakpoint for checking data is coming or not.
5. i have also checked via main.go file by calling my function.


## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [] I have tested it for all user roles.
* [] I have added all the required unit/api test cases.


