### PR TITLE
Fix: added missing MaxHistory param in UpgradeReleaseWithCustomChart

### DIFF
--- a/pkg/service/HelmAppService.go
+++ b/pkg/service/HelmAppService.go
@@ -1561,6 +1561,7 @@ func (impl HelmAppServiceImpl) UpgradeReleaseWithCustomChart(ctx context.Context
 		Namespace:   releaseIdentifier.ReleaseNamespace,
 		ValuesYaml:  request.ValuesYaml,
 		ChartName:   referenceChartDir,
+		MaxHistory:  int(request.HistoryMax),
 	}
 
 	impl.logger.Debug("Upgrading release")


### PR DESCRIPTION
Fixes https://github.com/devtron-labs/devtron/issues/3875


With the introduction of new api UpgradeReleaseWithCustomChart, the MaxHistory param was being received in request but was not being transferred to helmClient thus resulting in default limit of 0. 