### PR TITLE
fix: invalid old pods flag data with rollout deployment

### DIFF
--- a/pkg/service/HelmAppService.go
+++ b/pkg/service/HelmAppService.go
@@ -1337,7 +1337,8 @@ func buildPodMetadata(nodes []*bean.ResourceNode) ([]*bean.PodMetadata, error) {
 
 				// if parent of replicaset is deployment, compare label pod-template-hash
 				if replicaSetNode != nil && len(replicaSetNode.ParentRefs) > 0 && replicaSetNode.ParentRefs[0].Kind == kube.DeploymentKind {
-					isNew = replicaSet.GetLabels()["pod-template-hash"] == pod.GetLabels()["pod-template-hash"]
+					isNew = replicaSet.GetLabels()["pod-template-hash"] == pod.GetLabels()["pod-template-hash"] ||
+						replicaSet.GetLabels()["rollouts-pod-template-hash"] == pod.GetLabels()["rollouts-pod-template-hash"]
 				}
 			}
 

--- a/pkg/service/HelmAppService.go
+++ b/pkg/service/HelmAppService.go
@@ -1336,9 +1336,12 @@ func buildPodMetadata(nodes []*bean.ResourceNode) ([]*bean.PodMetadata, error) {
 				replicaSetNode := getMatchingNode(nodes, parentKind, replicaSet.Name)
 
 				// if parent of replicaset is deployment, compare label pod-template-hash
-				if replicaSetNode != nil && len(replicaSetNode.ParentRefs) > 0 && replicaSetNode.ParentRefs[0].Kind == kube.DeploymentKind {
-					isNew = replicaSet.GetLabels()["pod-template-hash"] == pod.GetLabels()["pod-template-hash"] ||
-						replicaSet.GetLabels()["rollouts-pod-template-hash"] == pod.GetLabels()["rollouts-pod-template-hash"]
+				if replicaSetNode != nil && len(replicaSetNode.ParentRefs) > 0 {
+					if replicaSetNode.ParentRefs[0].Kind == kube.DeploymentKind {
+						isNew = replicaSet.GetLabels()["pod-template-hash"] == pod.GetLabels()["pod-template-hash"]
+					} else if replicaSetNode.ParentRefs[0].Kind == kube.RolloutKind {
+						isNew = replicaSet.GetLabels()["rollouts-pod-template-hash"] == pod.GetLabels()["rollouts-pod-template-hash"]
+					}
 				}
 			}
 

--- a/pkg/util/kube/kube.go
+++ b/pkg/util/kube/kube.go
@@ -12,6 +12,7 @@ const (
 	ServiceAccountKind           = "ServiceAccount"
 	EndpointsKind                = "Endpoints"
 	DeploymentKind               = "Deployment"
+	RolloutKind                  = "Rollout"
 	ReplicaSetKind               = "ReplicaSet"
 	StatefulSetKind              = "StatefulSet"
 	DaemonSetKind                = "DaemonSet"


### PR DESCRIPTION
### Invalid old pod flag data in case of Rollout deployments:

The level used to distinguish for Old vs New Pods is different for Rollout Deployment Charts and Deployment Charts. And the handling is done for Deployment Charts only. This PR adds the handling for Rollout Deployment Charts as well.