### PR TITLE
fix: added safety error return in app detail when release does not exists

### DIFF
--- a/pkg/service/HelmAppServiceWrapper.go
+++ b/pkg/service/HelmAppServiceWrapper.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"github.com/devtron-labs/kubelink/bean"
 	"github.com/devtron-labs/kubelink/grpc"
 	"github.com/devtron-labs/kubelink/internal/lock"
@@ -68,7 +69,7 @@ func (impl *ApplicationServiceServerImpl) GetAppDetail(ctxt context.Context, req
 	helmAppDetail, err := impl.HelmAppService.BuildAppDetail(req)
 	if err != nil {
 		if helmAppDetail != nil && !helmAppDetail.ReleaseExists {
-			return &client.AppDetail{ReleaseExist: false}, nil
+			return &client.AppDetail{ReleaseExist: false}, fmt.Errorf("release not exists for this app")
 		}
 		impl.Logger.Errorw("Error in getting app detail", "clusterName", req.ClusterConfig.ClusterName, "releaseName", req.ReleaseName,
 			"namespace", req.Namespace, "err", err)


### PR DESCRIPTION
In GetAppDetail method we were returning object with release existence data for async installation handling in orchestrator. Added error for safety in future uses as earlier we used to return only the error and not the release exists data.  