### PR TITLE
fix: error shadowed in helm update

### DIFF
--- a/pkg/service/HelmAppServiceWrapper.go
+++ b/pkg/service/HelmAppServiceWrapper.go
@@ -173,6 +173,7 @@ func (impl *ApplicationServiceServerImpl) UpgradeRelease(ctx context.Context, in
 	res, err := impl.HelmAppService.UpgradeRelease(ctx, in)
 	if err != nil {
 		impl.Logger.Errorw("Error in Upgrade release request", "err", err)
+		return res, err
 	}
 	impl.Logger.Info("Upgrade release request served")
 


### PR DESCRIPTION
In devtron app helm update function error is not returned from kubelink.
https://github.com/devtron-labs/devtron/issues/3968