### PR TITLE
fix: checking if cluster ID is in clusterId list then only sync cluster cache

### DIFF
--- a/pkg/cache/ClusterMetadataCacheService.go
+++ b/pkg/cache/ClusterMetadataCacheService.go
@@ -71,6 +71,10 @@ func (impl *ClusterCacheImpl) getClusterInfoByClusterId(clusterId int) (*bean.Cl
 }
 
 func (impl *ClusterCacheImpl) OnStateChange(clusterId int, action string) {
+	isValidClusterId := isInClusterIdList(clusterId, impl.clusterCacheConfig.ClusterIdList)
+	if !isValidClusterId {
+		return
+	}
 	switch action {
 	case k8sInformer.UPDATE:
 		clusterInfo, err := impl.getClusterInfoByClusterId(clusterId)

--- a/pkg/cache/utils.go
+++ b/pkg/cache/utils.go
@@ -203,9 +203,9 @@ func setHibernationRules(res *bean.ResourceNode, un *unstructured.Unstructured) 
 	}
 }
 
-func isInClusterIdList(value int, list []int) bool {
-	for _, v := range list {
-		if v == value {
+func isInClusterIdList(clusterId int, clusterIdList []int) bool {
+	for _, id := range clusterIdList {
+		if id == clusterId {
 			return true
 		}
 	}

--- a/pkg/cache/utils.go
+++ b/pkg/cache/utils.go
@@ -202,3 +202,12 @@ func setHibernationRules(res *bean.ResourceNode, un *unstructured.Unstructured) 
 		}
 	}
 }
+
+func isInClusterIdList(value int, list []int) bool {
+	for _, v := range list {
+		if v == value {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This pr fixes the issue where there was no check for when a particular cluster update happening is present in the CLUSTER_ID_LIST flag.