### PR TITLE
feat(db): extract model define and add auto create table func

### DIFF
--- a/converter/ClusterBeanConverter.go
+++ b/converter/ClusterBeanConverter.go
@@ -20,7 +20,7 @@ import (
 	k8sUtils "github.com/devtron-labs/common-lib/utils/k8s"
 	"github.com/devtron-labs/kubelink/bean"
 	client "github.com/devtron-labs/kubelink/grpc"
-	repository "github.com/devtron-labs/kubelink/pkg/cluster"
+	repository "github.com/devtron-labs/kubelink/pkg/model"
 )
 
 type ClusterBeanConverter interface {

--- a/pkg/cluster/ClusterRepository.go
+++ b/pkg/cluster/ClusterRepository.go
@@ -17,41 +17,11 @@
 package repository
 
 import (
-	"github.com/devtron-labs/kubelink/pkg/remoteConnection"
-	"github.com/devtron-labs/kubelink/pkg/sql"
+	"github.com/devtron-labs/kubelink/pkg/model"
 	"github.com/go-pg/pg"
 	"github.com/go-pg/pg/orm"
 	"go.uber.org/zap"
 )
-
-type Cluster struct {
-	tableName                struct{}          `sql:"cluster" pg:",discard_unknown_columns"`
-	Id                       int               `sql:"id,pk"`
-	ClusterName              string            `sql:"cluster_name"`
-	ServerUrl                string            `sql:"server_url"`
-	RemoteConnectionConfigId int               `sql:"remote_connection_config_id"`
-	PrometheusEndpoint       string            `sql:"prometheus_endpoint"`
-	Active                   bool              `sql:"active,notnull"`
-	CdArgoSetup              bool              `sql:"cd_argo_setup,notnull"`
-	Config                   map[string]string `sql:"config"`
-	PUserName                string            `sql:"p_username"`
-	PPassword                string            `sql:"p_password"`
-	PTlsClientCert           string            `sql:"p_tls_client_cert"`
-	PTlsClientKey            string            `sql:"p_tls_client_key"`
-	AgentInstallationStage   int               `sql:"agent_installation_stage"`
-	K8sVersion               string            `sql:"k8s_version"`
-	ErrorInConnecting        string            `sql:"error_in_connecting"`
-	IsVirtualCluster         bool              `sql:"is_virtual_cluster"`
-	InsecureSkipTlsVerify    bool              `sql:"insecure_skip_tls_verify"`
-	ProxyUrl                 string            `sql:"proxy_url"`
-	ToConnectWithSSHTunnel   bool              `sql:"to_connect_with_ssh_tunnel"`
-	SSHTunnelUser            string            `sql:"ssh_tunnel_user"`
-	SSHTunnelPassword        string            `sql:"ssh_tunnel_password"`
-	SSHTunnelAuthKey         string            `sql:"ssh_tunnel_auth_key"`
-	SSHTunnelServerAddress   string            `sql:"ssh_tunnel_server_address"`
-	RemoteConnectionConfig   *remoteConnection.RemoteConnectionConfig
-	sql.AuditLog
-}
 
 func NewClusterRepositoryImpl(dbConnection *pg.DB, logger *zap.SugaredLogger) *ClusterRepositoryImpl {
 	return &ClusterRepositoryImpl{
@@ -66,13 +36,13 @@ type ClusterRepositoryImpl struct {
 }
 
 type ClusterRepository interface {
-	FindAllActive() ([]*Cluster, error)
-	FindById(id int) (*Cluster, error)
-	FindByIdWithActiveFalse(id int) (*Cluster, error)
+	FindAllActive() ([]*model.Cluster, error)
+	FindById(id int) (*model.Cluster, error)
+	FindByIdWithActiveFalse(id int) (*model.Cluster, error)
 }
 
-func (impl ClusterRepositoryImpl) FindAllActive() ([]*Cluster, error) {
-	var clusters []*Cluster
+func (impl ClusterRepositoryImpl) FindAllActive() ([]*model.Cluster, error) {
+	var clusters []*model.Cluster
 	err := impl.dbConnection.
 		Model(&clusters).
 		Column("cluster.*", "RemoteConnectionConfig").
@@ -86,8 +56,8 @@ func (impl ClusterRepositoryImpl) FindAllActive() ([]*Cluster, error) {
 	return clusters, err
 }
 
-func (impl ClusterRepositoryImpl) FindById(id int) (*Cluster, error) {
-	var cluster Cluster
+func (impl ClusterRepositoryImpl) FindById(id int) (*model.Cluster, error) {
+	var cluster model.Cluster
 	err := impl.dbConnection.
 		Model(&cluster).
 		Column("cluster.*", "RemoteConnectionConfig").
@@ -97,8 +67,8 @@ func (impl ClusterRepositoryImpl) FindById(id int) (*Cluster, error) {
 	return &cluster, err
 }
 
-func (impl ClusterRepositoryImpl) FindByIdWithActiveFalse(id int) (*Cluster, error) {
-	var cluster Cluster
+func (impl ClusterRepositoryImpl) FindByIdWithActiveFalse(id int) (*model.Cluster, error) {
+	var cluster model.Cluster
 	err := impl.dbConnection.
 		Model(&cluster).
 		Column("cluster.*", "RemoteConnectionConfig").

--- a/pkg/model/AuditLog.go
+++ b/pkg/model/AuditLog.go
@@ -1,0 +1,12 @@
+package model
+
+import (
+	"time"
+)
+
+type AuditLog struct {
+	CreatedOn time.Time `sql:"created_on,type:timestamptz"`
+	CreatedBy int32     `sql:"created_by,type:integer"`
+	UpdatedOn time.Time `sql:"updated_on,type:timestamptz"`
+	UpdatedBy int32     `sql:"updated_by,type:integer"`
+}

--- a/pkg/model/Cluster.go
+++ b/pkg/model/Cluster.go
@@ -1,0 +1,30 @@
+package model
+
+type Cluster struct {
+	tableName                struct{}          `sql:"cluster" pg:",discard_unknown_columns"`
+	Id                       int               `sql:"id,pk"`
+	ClusterName              string            `sql:"cluster_name"`
+	ServerUrl                string            `sql:"server_url"`
+	RemoteConnectionConfigId int               `sql:"remote_connection_config_id"`
+	PrometheusEndpoint       string            `sql:"prometheus_endpoint"`
+	Active                   bool              `sql:"active,notnull"`
+	CdArgoSetup              bool              `sql:"cd_argo_setup,notnull"`
+	Config                   map[string]string `sql:"config"`
+	PUserName                string            `sql:"p_username"`
+	PPassword                string            `sql:"p_password"`
+	PTlsClientCert           string            `sql:"p_tls_client_cert"`
+	PTlsClientKey            string            `sql:"p_tls_client_key"`
+	AgentInstallationStage   int               `sql:"agent_installation_stage"`
+	K8sVersion               string            `sql:"k8s_version"`
+	ErrorInConnecting        string            `sql:"error_in_connecting"`
+	IsVirtualCluster         bool              `sql:"is_virtual_cluster"`
+	InsecureSkipTlsVerify    bool              `sql:"insecure_skip_tls_verify"`
+	ProxyUrl                 string            `sql:"proxy_url"`
+	ToConnectWithSSHTunnel   bool              `sql:"to_connect_with_ssh_tunnel"`
+	SSHTunnelUser            string            `sql:"ssh_tunnel_user"`
+	SSHTunnelPassword        string            `sql:"ssh_tunnel_password"`
+	SSHTunnelAuthKey         string            `sql:"ssh_tunnel_auth_key"`
+	SSHTunnelServerAddress   string            `sql:"ssh_tunnel_server_address"`
+	RemoteConnectionConfig   *RemoteConnectionConfig
+	AuditLog
+}

--- a/pkg/model/RemoteConnectionConfig.go
+++ b/pkg/model/RemoteConnectionConfig.go
@@ -1,0 +1,18 @@
+package model
+
+import (
+	remoteConnectionBean "github.com/devtron-labs/common-lib/utils/remoteConnection/bean"
+)
+
+type RemoteConnectionConfig struct {
+	tableName        struct{}                                    `sql:"remote_connection_config" pg:",discard_unknown_columns"`
+	Id               int                                         `sql:"id,pk"`
+	ConnectionMethod remoteConnectionBean.RemoteConnectionMethod `sql:"connection_method"`
+	ProxyUrl         string                                      `sql:"proxy_url"`
+	SSHServerAddress string                                      `sql:"ssh_server_address"`
+	SSHUsername      string                                      `sql:"ssh_username"`
+	SSHPassword      string                                      `sql:"ssh_password"`
+	SSHAuthKey       string                                      `sql:"ssh_auth_key"`
+	Deleted          bool                                        `sql:"deleted,notnull"`
+	AuditLog
+}

--- a/pkg/remoteConnection/RemoteConnectionRepository.go
+++ b/pkg/remoteConnection/RemoteConnectionRepository.go
@@ -17,14 +17,13 @@
 package remoteConnection
 
 import (
-	remoteConnectionBean "github.com/devtron-labs/common-lib/utils/remoteConnection/bean"
-	"github.com/devtron-labs/kubelink/pkg/sql"
+	"github.com/devtron-labs/kubelink/pkg/model"
 	"github.com/go-pg/pg"
 	"go.uber.org/zap"
 )
 
 type RemoteConnectionRepository interface {
-	GetById(id int) (*RemoteConnectionConfig, error)
+	GetById(id int) (*model.RemoteConnectionConfig, error)
 }
 
 type RemoteConnectionRepositoryImpl struct {
@@ -39,21 +38,8 @@ func NewRemoteConnectionRepositoryImpl(dbConnection *pg.DB, logger *zap.SugaredL
 	}
 }
 
-type RemoteConnectionConfig struct {
-	tableName        struct{}                                    `sql:"remote_connection_config" pg:",discard_unknown_columns"`
-	Id               int                                         `sql:"id,pk"`
-	ConnectionMethod remoteConnectionBean.RemoteConnectionMethod `sql:"connection_method"`
-	ProxyUrl         string                                      `sql:"proxy_url"`
-	SSHServerAddress string                                      `sql:"ssh_server_address"`
-	SSHUsername      string                                      `sql:"ssh_username"`
-	SSHPassword      string                                      `sql:"ssh_password"`
-	SSHAuthKey       string                                      `sql:"ssh_auth_key"`
-	Deleted          bool                                        `sql:"deleted,notnull"`
-	sql.AuditLog
-}
-
-func (repo *RemoteConnectionRepositoryImpl) GetById(id int) (*RemoteConnectionConfig, error) {
-	model := &RemoteConnectionConfig{}
+func (repo *RemoteConnectionRepositoryImpl) GetById(id int) (*model.RemoteConnectionConfig, error) {
+	model := &model.RemoteConnectionConfig{}
 	err := repo.dbConnection.Model(model).
 		Where("id = ?", id).
 		Where("deleted = ?", false).

--- a/pkg/sql/connection.go
+++ b/pkg/sql/connection.go
@@ -17,6 +17,8 @@
 package sql
 
 import (
+	"github.com/devtron-labs/kubelink/pkg/model"
+	"github.com/go-pg/pg/orm"
 	"go.uber.org/zap"
 	"reflect"
 	"time"
@@ -62,6 +64,19 @@ func NewDbConnection(cfg *Config, logger *zap.SugaredLogger) (*pg.DB, error) {
 		return nil, err
 	} else {
 		logger.Infow("connected with db", "db", obfuscateSecretTags(cfg))
+	}
+
+	// automatically create tables
+	tables := []interface{}{(*model.RemoteConnectionConfig)(nil), (*model.Cluster)(nil)}
+
+	for _, table := range tables {
+		err = dbConnection.Model(table).CreateTable(&orm.CreateTableOptions{
+			IfNotExists: true,
+		})
+		if err != nil {
+			logger.Errorw("error in creating table", "table", table, "err", err)
+			return nil, err
+		}
 	}
 
 	//--------------


### PR DESCRIPTION
When using helm to deploy devtron, when adjusting the replicas of kubelink Deployment to 0 and then restoring it, an error is reported as follows:
<img width="1944" alt="image" src="https://github.com/user-attachments/assets/c88ac520-85a6-43ac-8d71-15843f9bc027" />


The reason is that the automatic table creation function has not been added.